### PR TITLE
Use local test files

### DIFF
--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -3,7 +3,7 @@ use egraph_serialize::*;
 #[test]
 fn test_round_trip() {
     let mut n_tested = 0;
-    let pattern = "../extraction-gym/data/**/*.json";
+    let pattern = "tests/*.json";
     for entry in glob::glob(pattern).expect("Failed to read glob pattern") {
         let entry = entry.unwrap();
         println!("Testing {:?}", entry);


### PR DESCRIPTION
This changes the tests to use the local files instead of those in the extraction gym repo. I made this change so I could test the addition of classes.

Feel free to disregard if you prefer testing the extraction gym files.