### PR TITLE
Children are classes not nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ where
                     children: node
                         .children()
                         .iter()
-                        .map(|id| NodeId::from(format!("{}.0", id)))
+                        .map(|id| ClassId::from(format!("{}", id)))
                         .collect(),
                     eclass: ClassId::from(format!("{}", class.id)),
                     cost: Cost::new(1.0).unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ impl std::ops::Index<&ClassId> for EGraph {
 pub struct Node {
     pub op: String,
     #[cfg_attr(feature = "serde", serde(default))]
-    pub children: Vec<NodeId>,
+    pub children: Vec<ClassId>,
     pub eclass: ClassId,
     #[cfg_attr(feature = "serde", serde(default = "one"))]
     pub cost: Cost,


### PR DESCRIPTION
I believe that the children should point to e-classes, instead of particular node IDs.