### PR TITLE
Escape newlines in graphviz output

### DIFF
--- a/src/graphviz.rs
+++ b/src/graphviz.rs
@@ -172,6 +172,7 @@ fn quote(s: &str) -> String {
 }
 
 // Copied from https://doc.rust-lang.org/stable/nightly-rustc/src/rustdoc/html/escape.rs.html#10
+// but added conversion of \n to <br>
 
 /// Wrapper struct which will emit the HTML-escaped version of the contained
 /// string when passed to a format string.
@@ -191,6 +192,7 @@ impl<'a> fmt::Display for Escape<'a> {
                 '&' => "&amp;",
                 '\'' => "&#39;",
                 '"' => "&quot;",
+                '\n' => "<br>",
                 _ => continue,
             };
             fmt.write_str(&pile_o_bits[last..i])?;

--- a/src/graphviz.rs
+++ b/src/graphviz.rs
@@ -149,7 +149,7 @@ const INITIAL_COLOR: usize = 2;
 /// Returns an html label for the node with the function name and ports for each argumetn
 fn html_label(label: &str, n_args: usize) -> String {
     format!(
-        "<<TABLE BGCOLOR=\"white\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\" style=\"rounded\"><tr><td BALIGN="left" CELLPADDING=\"4\" WIDTH=\"30\" HEIGHT=\"30\"{}>{}</td></tr>{}</TABLE>>",
+        "<<TABLE BGCOLOR=\"white\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\" style=\"rounded\"><tr><td BALIGN=\"left\" CELLPADDING=\"4\" WIDTH=\"30\" HEIGHT=\"30\"{}>{}</td></tr>{}</TABLE>>",
         (if n_args  == 0 {"".to_string()} else {format!(" colspan=\"{}\"", n_args)}),
         Escape(label),
         (if n_args == 0 {

--- a/src/graphviz.rs
+++ b/src/graphviz.rs
@@ -149,7 +149,7 @@ const INITIAL_COLOR: usize = 2;
 /// Returns an html label for the node with the function name and ports for each argumetn
 fn html_label(label: &str, n_args: usize) -> String {
     format!(
-        "<<TABLE BGCOLOR=\"white\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\" style=\"rounded\"><tr><td CELLPADDING=\"4\" WIDTH=\"30\" HEIGHT=\"30\"{}>{}</td></tr>{}</TABLE>>",
+        "<<TABLE BGCOLOR=\"white\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\" style=\"rounded\"><tr><td BALIGN="left" CELLPADDING=\"4\" WIDTH=\"30\" HEIGHT=\"30\"{}>{}</td></tr>{}</TABLE>>",
         (if n_args  == 0 {"".to_string()} else {format!(" colspan=\"{}\"", n_args)}),
         Escape(label),
         (if n_args == 0 {

--- a/src/graphviz.rs
+++ b/src/graphviz.rs
@@ -172,7 +172,7 @@ fn quote(s: &str) -> String {
 }
 
 // Copied from https://doc.rust-lang.org/stable/nightly-rustc/src/rustdoc/html/escape.rs.html#10
-// but added conversion of \n to <br>
+// but added conversion of \n to <br/>
 
 /// Wrapper struct which will emit the HTML-escaped version of the contained
 /// string when passed to a format string.
@@ -192,7 +192,7 @@ impl<'a> fmt::Display for Escape<'a> {
                 '&' => "&amp;",
                 '\'' => "&#39;",
                 '"' => "&quot;",
-                '\n' => "<br>",
+                '\n' => "<br/>",
                 _ => continue,
             };
             fmt.write_str(&pile_o_bits[last..i])?;


### PR DESCRIPTION
This PR adds support for rendering nodes in graphviz that contain newlines (`\n`). 

Note that the default egglog parser is not able to create strings with newlines (i.e. the string `"\n"` ends up with the newline escaped during parsing), but the Python bindings are able to create them.

Previously, newlines were emitted as-is in the graphviz output, as newlines in the file, which meant they were not rendered.

I tested this PR with this code:

```python
from egglog import *

egraph = EGraph()

@egraph.function
def f() -> String: ...

egraph.register(set_(f()).to(String("Hello\nWorld!")))
egraph.display()
```

Which now renders like this:

<img width="275" alt="Screenshot 2023-09-02 at 9 43 26 AM" src="https://github.com/egraphs-good/egraph-serialize/assets/1186124/56503591-f9e3-4c08-a24c-bd910d89bd78">


But previously was like this:

<img width="343" alt="Screenshot 2023-09-02 at 9 43 59 AM" src="https://github.com/egraphs-good/egraph-serialize/assets/1186124/1a827273-8f7d-46b3-8af9-8365353b673e">


EDIT: I also added a `BALIGN="left"` so that the lines separated by `<br />` are aligned left, instead of centered, and tested this.
